### PR TITLE
Updates CodeAnalysis references to latest version

### DIFF
--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS.Test/Analyzer_CS.Test.vbproj
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS.Test/Analyzer_CS.Test.vbproj
@@ -44,28 +44,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS.Test/packages.config
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS/Analyzer_CS.vbproj
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS/Analyzer_CS.vbproj
@@ -92,18 +92,16 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS/packages.config
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_CS/Analyzer_CS/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB.Test/Analyzer_VB.Test.vbproj
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB.Test/Analyzer_VB.Test.vbproj
@@ -44,28 +44,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB.Test/packages.config
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB/Analyzer_VB.vbproj
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB/Analyzer_VB.vbproj
@@ -92,20 +92,16 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB/packages.config
+++ b/Analyzer_Constructor_Mis-Assignment/Analyzer_VB/Analyzer_VB/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />

--- a/DotNetAnalyzers/DotNetAnalyzers.Test/DotNetAnalyzers.Test.csproj
+++ b/DotNetAnalyzers/DotNetAnalyzers.Test/DotNetAnalyzers.Test.csproj
@@ -35,28 +35,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/DotNetAnalyzers/DotNetAnalyzers.Test/packages.config
+++ b/DotNetAnalyzers/DotNetAnalyzers.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />

--- a/DotNetAnalyzers/DotNetAnalyzers/DotNetAnalyzers.csproj
+++ b/DotNetAnalyzers/DotNetAnalyzers/DotNetAnalyzers.csproj
@@ -52,20 +52,16 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/DotNetAnalyzers/DotNetAnalyzers/packages.config
+++ b/DotNetAnalyzers/DotNetAnalyzers/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />

--- a/DotNetRefactoring/DotNetRefactoring.Test/DotNetRefactoring.Test.csproj
+++ b/DotNetRefactoring/DotNetRefactoring.Test/DotNetRefactoring.Test.csproj
@@ -35,28 +35,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/DotNetRefactoring/DotNetRefactoring.Test/packages.config
+++ b/DotNetRefactoring/DotNetRefactoring.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141030-05" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />

--- a/DotNetRefactoring/DotNetRefactoring/DotNetRefactoring.csproj
+++ b/DotNetRefactoring/DotNetRefactoring/DotNetRefactoring.csproj
@@ -38,20 +38,16 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141030-05\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/DotNetRefactoring/DotNetRefactoring/packages.config
+++ b/DotNetRefactoring/DotNetRefactoring/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141030-05" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />


### PR DESCRIPTION
From version=`1.0.0-beta1-20141030-05` to version=`1.0.0.0-beta2`

This brings `DotNetAnalyzers` and `DotNetRefactoring` projects up to date and makes them buildable. This is similar to [this commit](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/commit/575019de27de6199dcdc75968646fa4b0c4556af?diff=split#diff-a9bf93c8cfc0f1a090df05bc995393f9R257) by @sharwell.

I've also brought up to date (but not included in this PR) packages used by solution `Mis-AssignmentInConstructors` merged in PR #2. However, the code uses old Roslyn API, and first I would like to discuss whether this solution belongs in this repository. I think it's better suited in its own repository, so I'd like to ask you for opinions :)

Solution `DotNetAnalyzers` contains projects from _another solution_ `Mis-AssignmentInConstructors`. Users who newly cloned the `DotNetAnalyzers` repository could never run the code, because building solution `DotNetAnalyzers` does not update the nuget packages for other solutions embedded within it. The `DotNetAnalyzers` solution could only build if developer successfully built the solution `Mis-AssignmentInConstructors` (hidden in folder hierarchy) separately, or unloaded its projects from the main solution. This is a poor design which prevents developers from readily taking advantage of this repository.

This brings me to question - what is the purpose of `DotNetAnalyzers` repository? The description states _This project is for the community to make a common code base of_ [for?] _.NET code analyzers using the new VS14 code analyzer functionality._ Does it mean that this repository is a template for developers to use when building their own analyzers, or a solution that encompasses multiple analyzers?
If it's the former, then I believe that `Mis-AssignmentInConstructors` deserves its own repository [within DotNetAnalyzers organization](https://github.com/DotNetAnalyzers).
